### PR TITLE
feat: add the 'stopNFC' and 'startNFC' methods

### DIFF
--- a/android/src/main/java/com/tangem/TangemSdkReactNative/TangemSdkReactNativeModule.kt
+++ b/android/src/main/java/com/tangem/TangemSdkReactNative/TangemSdkReactNativeModule.kt
@@ -106,6 +106,25 @@ class TangemSdkReactNativeModule(private val reactContext: ReactApplicationConte
     }
 
     @ReactMethod
+    fun nfcStop() {
+        if (::nfcManager.isInitialized) {
+            nfcManager.onStop()
+            nfcManagerStarted = false
+        }
+    }
+
+    @ReactMethod
+    fun nfcStart() {
+        if (!::nfcManager.isInitialized) return
+        val activity = wActivity.get() ?: return
+
+        if (activity.isDestroyed() || activity.isFinishing()) {
+            initialize()
+        }
+        if (!nfcManagerStarted) nfcManager.onStart()
+    }
+
+    @ReactMethod
     fun createWallet(param: ReadableMap, promise: Promise) {
         try {
             sdk.createWallet(

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,8 @@ const tangemSdk: TangemSdk = {
   startSession: () => RNTangemSdk.startSession(),
   stopSession: () => RNTangemSdk.stopSession(),
   getNFCStatus: () => RNTangemSdk.getNFCStatus(),
+  nfcStop: () => RNTangemSdk.nfcStop(),
+  nfcStart: () => RNTangemSdk.nfcStart(),
 
   /**
    * Listen for available events (Android)

--- a/src/types.ts
+++ b/src/types.ts
@@ -519,6 +519,10 @@ export interface TangemSdk {
 
   getNFCStatus(): Promise<NFCStatusResponse>;
 
+  nfcStop(): Promise<void>;
+
+  nfcStart(): Promise<void>;
+
   on(eventName: Events, handler: (state: EventCallback) => void): void;
 
   removeListener(


### PR DESCRIPTION
Fix: https://github.com/tangem/tangem-sdk-react-native/issues/19

I included two new methods `nfcStop` and `nfcStart`, so, we're able to activate or deactivate the NFC feature on the SDK when that is required, for instance, to use a different NFC library.